### PR TITLE
aubuf: read also last frame if it has not the full size

### DIFF
--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -177,6 +177,7 @@ int aubuf_write(struct aubuf *ab, const uint8_t *p, size_t sz)
 void aubuf_read(struct aubuf *ab, uint8_t *p, size_t sz)
 {
 	struct le *le;
+	bool filling;
 
 	if (!ab || !p || !sz)
 		return;
@@ -191,12 +192,15 @@ void aubuf_read(struct aubuf *ab, uint8_t *p, size_t sz)
 					ab, ab->cur_sz);
 		}
 #endif
+		filling = ab->filling;
 		ab->filling = true;
 		memset(p, 0, sz);
-		goto out;
+		if (filling)
+			goto out;
 	}
-
-	ab->filling = false;
+	else {
+		ab->filling = false;
+	}
 
 	le = ab->afl.head;
 


### PR DESCRIPTION
aubuf: read also last frame if it has not the full size

If the last frame in the aubuf is smaller than the wanted size, then aubuf_read
should return this part and fill up to the rest of the frame with silence.

In most use cases complete frames are pushed. But module/aufile also uses aubuf and may finish with writing a partly frame. If this final frame is not pushed into the auplay, it may lead to an unclean end.