### PR TITLE
Makefile: allow LIBRE_MK to be set outside

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ PROJECT   := rem
 VERSION   := $(VER_MAJOR).$(VER_MINOR).$(VER_PATCH)
 OPT_SPEED := 1
 
+ifndef LIBRE_MK
 LIBRE_MK  := $(shell [ -f ../re/mk/re.mk ] && \
 	echo "../re/mk/re.mk")
 ifeq ($(LIBRE_MK),)
@@ -22,6 +23,7 @@ endif
 ifeq ($(LIBRE_MK),)
 LIBRE_MK  := $(shell [ -f /usr/local/share/re/re.mk ] && \
 	echo "/usr/local/share/re/re.mk")
+endif
 endif
 
 include $(LIBRE_MK)


### PR DESCRIPTION
E.g. for cross compilation it may be necessary to specify the location of
re.mk where make is called.

@sreimers Same solution in baresip/Makefile. What I have found by reading Makefile doc and by small test Makefiles is that the ":=" always overwrites the variable. Setting LIBRE_MK from outside  was not possible. So it seems to be the correct solution? 