### PR TITLE
auframe: move to rem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ include $(LIBRE_MK)
 MODULES += fir goertzel
 MODULES += g711
 MODULES += aubuf aufile auresamp autone dtmf
-MODULES += au auconv aulevel
+MODULES += au auconv aulevel auframe
 
 ifneq ($(HAVE_LIBPTHREAD),)
 MODULES += aumix vidmix

--- a/include/rem_audio.h
+++ b/include/rem_audio.h
@@ -6,6 +6,7 @@
 
 
 #include "rem_au.h"
+#include "rem_auframe.h"
 #include "rem_aubuf.h"
 #include "rem_auconv.h"
 #include "rem_aufile.h"

--- a/include/rem_auframe.h
+++ b/include/rem_auframe.h
@@ -1,0 +1,20 @@
+/*
+ * Audio frame
+ */
+
+/**
+ * Defines a frame of audio samples
+ */
+struct auframe {
+	int fmt;             /**< Sample format (enum aufmt)        */
+	void *sampv;         /**< Audio samples (must be mem_ref'd) */
+	size_t sampc;        /**< Total number of audio samples     */
+	uint64_t timestamp;  /**< Timestamp in AUDIO_TIMEBASE units */
+	uint32_t srate;      /**< Samplerate                        */
+	uint8_t ch;          /**< Channels                          */
+};
+
+void auframe_init(struct auframe *af, int fmt, void *sampv, size_t sampc,
+		  uint32_t srate, uint8_t ch);
+size_t auframe_size(const struct auframe *af);
+void   auframe_mute(struct auframe *af);

--- a/src/auframe/auframe.c
+++ b/src/auframe/auframe.c
@@ -1,0 +1,78 @@
+/**
+ * @file auframe.c  Audio frame
+ *
+ * Copyright (C) 2010 - 2020 Alfred E. Heggestad
+ */
+
+#include <string.h>
+#include <re.h>
+#include <rem.h>
+
+
+/**
+ * Initialize an audio frame
+ *
+ * @param af       Audio frame
+ * @param fmt      Sample format (enum aufmt)
+ * @param sampv    Audio samples
+ * @param sampc    Total number of audio samples
+ * @param srate    Samplerate
+ * @param ch       Channels
+ */
+void auframe_init(struct auframe *af, int fmt, void *sampv, size_t sampc,
+		  uint32_t srate, uint8_t ch)
+{
+	if (!af)
+		return;
+
+	if (0 == aufmt_sample_size(fmt)) {
+		re_printf("auframe: init: unsupported sample format %d (%s)\n",
+			fmt, aufmt_name(fmt));
+	}
+
+	memset(af, 0, sizeof(*af));
+
+	af->fmt = fmt;
+	af->sampv = sampv;
+	af->sampc = sampc;
+	af->srate = srate;
+	af->ch = ch;
+}
+
+
+/**
+ * Get the size of an audio frame
+ *
+ * @param af Audio frame
+ *
+ * @return Number of bytes
+ */
+size_t auframe_size(const struct auframe *af)
+{
+	size_t sz;
+
+	if (!af)
+		return 0;
+
+	sz = aufmt_sample_size(af->fmt);
+	if (sz == 0) {
+		re_printf("auframe: size: illegal format %d (%s)\n",
+			af->fmt, aufmt_name(af->fmt));
+	}
+
+	return af->sampc * sz;
+}
+
+
+/**
+ * Silence all samples in an audio frame
+ *
+ * @param af Audio frame
+ */
+void auframe_mute(struct auframe *af)
+{
+	if (!af)
+		return;
+
+	memset(af->sampv, 0, auframe_size(af));
+}

--- a/src/auframe/mod.mk
+++ b/src/auframe/mod.mk
@@ -1,0 +1,5 @@
+#
+# mod.mk
+#
+
+SRCS	+= auframe/auframe.c


### PR DESCRIPTION
Move `auframe` to rem, so we can add `aubuf` functions like 

```c
int  aubuf_init_auframe(struct aubuf *ab, struct auframe *af);
int  aubuf_write_auframe(struct aubuf *ab, struct auframe *af);
void aubuf_read_auframe(struct aubuf *ab, struct auframe *af);
```