### PR TITLE
Fix win32

### DIFF
--- a/mk/win32/rem.vcxproj
+++ b/mk/win32/rem.vcxproj
@@ -34,11 +34,16 @@
     <ClCompile Include="..\..\src\auconv\auconv.c" />
     <ClCompile Include="..\..\src\aufile\aufile.c" />
     <ClCompile Include="..\..\src\aufile\wave.c" />
+    <ClCompile Include="..\..\src\auframe\auframe.c" />
+    <ClCompile Include="..\..\src\aulevel\aulevel.c" />
     <ClCompile Include="..\..\src\auresamp\resamp.c" />
     <ClCompile Include="..\..\src\autone\tone.c" />
     <ClCompile Include="..\..\src\au\fmt.c" />
     <ClCompile Include="..\..\src\fir\fir.c" />
     <ClCompile Include="..\..\src\g711\g711.c" />
+    <ClCompile Include="..\..\src\h264\getbit.c" />
+    <ClCompile Include="..\..\src\h264\nal.c" />
+    <ClCompile Include="..\..\src\h264\sps.c" />
     <ClCompile Include="..\..\src\vidconv\vconv.c" />
     <ClCompile Include="..\..\src\vid\draw.c" />
     <ClCompile Include="..\..\src\vid\fmt.c" />

--- a/mk/win32/rem.vcxproj
+++ b/mk/win32/rem.vcxproj
@@ -97,6 +97,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <DisableSpecificWarnings>4142;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <ObjectFileName>$(IntDir)%(RelativeDir)%(Filename).obj</ObjectFileName>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Lib>
       <AdditionalOptions>Iphlpapi.lib %(AdditionalOptions)</AdditionalOptions>

--- a/mk/win32/rem.vcxproj.filters
+++ b/mk/win32/rem.vcxproj.filters
@@ -37,6 +37,15 @@
     <Filter Include="src\vidconv">
       <UniqueIdentifier>{68ad1019-ff82-4811-a9df-cfe0eabeea34}</UniqueIdentifier>
     </Filter>
+    <Filter Include="src\h264">
+      <UniqueIdentifier>{14f15124-fb62-4e8c-b72a-f5030e8c26eb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\auframe">
+      <UniqueIdentifier>{d945f852-21f4-486e-ad0f-fcc3afe287a2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\aulevel">
+      <UniqueIdentifier>{8ea230dd-39a5-4a91-a990-adb62cfc5037}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\rem.h">
@@ -133,5 +142,20 @@
     </ClCompile>
     <ClCompile Include="..\..\src\goertzel\goertzel.c" />
     <ClCompile Include="..\..\src\dtmf\dec.c" />
+    <ClCompile Include="..\..\src\h264\getbit.c">
+      <Filter>src\h264</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\h264\nal.c">
+      <Filter>src\h264</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\h264\sps.c">
+      <Filter>src\h264</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\auframe\auframe.c">
+      <Filter>src\auframe</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\aulevel\aulevel.c">
+      <Filter>src\aulevel</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
fix compiling whole Baresip solution (win32) in Visual Studio (2019) 