### PR TITLE
auframe: add auframe_update

### DIFF
--- a/include/rem_auframe.h
+++ b/include/rem_auframe.h
@@ -16,5 +16,25 @@ struct auframe {
 
 void auframe_init(struct auframe *af, enum aufmt fmt, void *sampv,
 		  size_t sampc, uint32_t srate, uint8_t ch);
+
+/**
+ * Update an audio frame
+ *
+ * @param af        Audio frame
+ * @param sampv     Audio samples
+ * @param sampc     Total number of audio samples
+ * @param timestamp Timestamp in AUDIO_TIMEBASE units
+ */
+static inline void auframe_update(struct auframe *af, void *sampv,
+				  size_t sampc, uint64_t timestamp)
+{
+	if (!af)
+		return;
+
+	af->sampv = sampv;
+	af->sampc = sampc;
+	af->timestamp = timestamp;
+}
+
 size_t auframe_size(const struct auframe *af);
 void   auframe_mute(struct auframe *af);


### PR DESCRIPTION
Only update necessary fields (since `srate`, `fmt` and `ch` should not change).

For example currently a audio record handler looks like this:

```c
record_handler(...)
{
  	struct auframe af;
...
	auframe_init(&af, st->prm.fmt, sampv, sampc, st->prm.srate, st->prm.ch);

	af.timestamp = AUDIO_TIMEBASE*inStartTime->mSampleTime / st->prm.srate;
...
}
```

new api:

```c

record_alloc(...)
{
        auframe_init(st->af, fmt, NULL, sampc, srate, ch);
}

record_handler(...)
{
	struct ausrc_st *st = userData;
...
	auframe_update(st->af, sampv, sampc, timestamp);
...
}
```