### PR TITLE
aubuf adaptive jitter buffer

### DIFF
--- a/docs/aubuf/.gitignore
+++ b/docs/aubuf/.gitignore
@@ -1,0 +1,2 @@
+ajb.dat
+ajb.eps

--- a/docs/aubuf/.gitignore
+++ b/docs/aubuf/.gitignore
@@ -1,2 +1,3 @@
 ajb.dat
 ajb.eps
+underrun.dat

--- a/docs/aubuf/README.md
+++ b/docs/aubuf/README.md
@@ -1,0 +1,168 @@
+This adaptive audio buffer implementation increases the number of packets in
+the buffer during periods of high network jitter. It reduces the number of
+packets if the network condition improves.
+
+
+## Computing the jitter
+
+The network jitter is computed similar to the proposition in RFC-3550 RTP
+section A.8 and similar how wireshark does it. The jitter is an exponential
+moving average (EMA) of the difference *d* between the real time and the RTP
+timestamps. Or more concretely we compute at each `ajb_calc()` the difference
+
+*d = Dt<sub>r</sub> -  Dt<sub>s</sub>*,
+
+where *Dt<sub>r</sub>* is the real time elapsed from last call to
+`ajb_calc()` and  *Dt<sub>s</sub>* is the difference of the timestamps. Then
+with a predefined speed *s* we compute the jitter *j* as moving average
+
+*j = j + s (|d| - j)*.
+
+We choose a higher value for speed *s* if *|d| > j*. Thus the jitter rises fast
+if e.g. suddenly a network jitter appears. In contrast when the network
+condition improves the jitter value slowly shrinks. The reason for different
+rising and falling speed is that we have to react fast to avoid buffer
+under-runs, whereas reducing of the latency may be done a while after the
+network condition improved.
+
+In the following sections we will describe how the computed jitter is used to
+detect situations where the buffered packets should be increased due to a high
+jitter. We call this situations **Low** situations. When the jitter shrinks
+below some specific value it is a good idea to reduce the buffer to reduce the
+audio latency. We call this situations **High** situations. Surely, the
+Low/High situations have to be decided somehow.
+
+## Reduce/Increase buffered packets
+
+When a Low situation is detected we increase the number of packets in `aubuf`
+by holding back a packet during one call to function `aubuf_read_auframe()`.
+While when a High situation is detected we reduce the number of packets by
+reading another audio frame. This overwrites one frame. By means of a silence
+detection `aubuf` is able to drop frames that are not important for the speech
+quality. This reduces the audio latency down to the value before the High
+situation.
+
+
+## Computing a smooth latency
+
+The audio frames that are buffered at a concrete point in time in `aubuf` lead
+to a temporary latency value l<sub>c</sub>. Let *f<sub>0</sub>, ...,
+f<sub>m</sub>* be the audio frames currently stored in `aubuf`. Then
+
+*l<sub>c</sub> = t<sub>m</sub> - t<sub>0</sub> + t<sub>p</sub>*,
+
+where *t<sub>i</sub>* is the timestamp of frame *f<sub>i</sub>* and
+*t<sub>p</sub>* is the packet time `ptime`. The packet time is a
+constant that is specified at the beginning of a SIP call. In baresip it is
+specified in the account file.
+
+The temporary latency *l<sub>c</sub>* is discontinuous over time and not
+adequate for deciding or detecting Low or High situations. Therefore we again
+use a exponential moving average (EMA) to smooth *l<sub>c</sub>*. Let *s* be an
+adequate moving average speed, then the smoothed latency
+
+*l = l + s (l<sub>c</sub> - l)*.
+
+Low/High situations are decided when the smoothed latency *l* runs out of some
+boundaries that are computed from the jitter.
+
+## Deciding Low/High situations
+
+During each iteration (each `aubuf_write_frame()`) the jitter and the latency
+are computed. Additionally we compute the bottom boundary *l<sub>b</sub>* and
+the top boundary *l<sub>t</sub>* with
+
+*l<sub>b</sub> = 1.25 j* and
+
+*l<sub>t</sub> = 2.2 j*.
+
+Since we want to respect also the parameter `min` of function `aubuf_alloc()`
+we extend these formulas. Let *m<sub>m</sub>* be the parameter `min`. Then
+
+*l<sub>b</sub> = max(m<sub>m</sub> 2 t<sub>p</sub> / 3, 1.25 j)* and
+
+*l<sub>t</sub> = max(l<sub>b</sub> + 4 t<sub>p</sub> / 3, 2.2 j)*,
+
+where *t<sub>p</sub>* is the `ptime` as defined already. Finally we have
+everything for deciding Low and High situations. That is if *l* moves out of
+the boundaries
+
+*l<sub>b</sub> < l < l<sub>t</sub>*
+
+then we fire a Low/High.
+
+## Early adjustment of the latency
+
+Finally, if we detect a Low/High situation we increase/reduce the number of
+packets. Now we immediately increment/decrement the smoothed latency *l* by
+one packet time. Thus early adjustment for a Low situation is
+
+*l = l + l<sub>p</sub>* and for a High situation
+*l = l - l<sub>p</sub>*.
+
+This avoids multiple Low/High detections in a row.
+
+## Silence detection
+
+It is preferable to drop an audio frame only if it contains nearly silence.
+
+## Math symbols vs. C-variables
+
+In order to avoid float computation we use micro seconds to measure the time
+differences, the jitter and buffer time. Symbols used in this document are
+mapped to the C-variables in `src/aubuf/ajb.c` like this table shows:
+
+
+Symbol|Variable
+------|--------
+*d*   | `d`
+*j*   | `jitter`
+*l*   | `avbuftime`
+*l<sub>c</sub>*   | `buftime`
+*l<sub>b</sub>*   | `bufmin`
+*l<sub>t</sub>*   | `bufmax`
+*t<sub>p</sub>*   | `ptime`
+
+
+## How to test adaptive aubuf
+
+- In aubuf.c set DEBUG\_LEVEL to 6, build and install libre again!
+
+- Add bridge interface linked to your Ethernet/WiFi interface! Suppose baresip
+is connected to the network interface *eth0*. Replace *eth0* with your physical
+network interface! See the man pages of "ip" and "tc" for further details!
+
+```
+sudo ip link add ifb1 type ifb || :
+sudo ip link set ifb1 up
+sudo tc qdisc add dev eth0 handle ffff: ingress
+sudo tc filter add dev eth0 parent ffff: u32 match u32 0 0 action mirred egress redirect dev ifb1
+```
+
+This redirects the incoming eth0 traffic to a new ifb interface.
+
+- How to activate the jitter. Here we set the delay to 100ms ± 50ms.
+```
+sudo tc qdisc add dev ifb1 root netem delay 100ms 50ms
+```
+
+- How to deactivate the jitter.
+```
+sudo tc qdisc del dev ifb1 root
+```
+
+- See/Use ajb.plot to generate a plot!
+
+Note:
+- Activate and deactivate the network jitter during a call to see how the
+adaptive audio buffer algorithm works!
+- You need a very new kernel or at least some patches for the `sch_netem`
+kernel module. There was a problem which lead to many reordered and very late
+RTP packets. Be sure that you have this commit in the kernel:
+```
+commit eadd1befdd778a1eca57fad058782bd22b4db804
+Author: Aleksandr Nogikh <nogikh@google.com>
+Date:   Wed Oct 28 17:07:31 2020 +0000
+
+    netem: fix zero division in tabledist
+```

--- a/docs/aubuf/accounts
+++ b/docs/aubuf/accounts
@@ -1,0 +1,1 @@
+<sip:alice@office>;regint=0;ptime=20

--- a/docs/aubuf/ajb.plot
+++ b/docs/aubuf/ajb.plot
@@ -66,14 +66,23 @@ set datafile separator ","
 set key outside
 set xlabel "time/[ms]"
 set ylabel "[ms]"
-plot \
-'ajb.dat' using 3:($5/1000) title 'jitter' with linespoints linecolor "orange", \
-'ajb.dat' using 3:($7/1000) title 'avbuftime' with linespoints linecolor "skyblue", \
-'ajb.dat' using 3:($8/1000) title 'bufmin' with linespoints linecolor "sea-green", \
-'ajb.dat' using 3:($9/1000) title 'bufmax' with linespoints linecolor "sea-green", \
-'ajb.dat' using 3:($10*10) title 'Good/Empty/Low/High' linecolor "red", \
-'ajb.dat' using 3:($6/1000) title 'buftime' linecolor "light-grey", \
-10 title "Empty=10" linecolor "red", \
-20 title "Low=20" linecolor "red", \
-30 title "High=30" linecolor "red"
 
+stats "ajb.dat" using ($6/1000) name "B"
+stats "ajb.dat" using 3 name "X"
+
+bufst(y) = y>0 ? B_max*0.8 + y*B_max*0.09 : NaN
+text1(y) = y==1 ? "LOW" : y==2 ? "HIGH" : ""
+text2(y) = y==1 ? "UNDERRUN" : ""
+underr(y) =  B_max*0.7 + y*B_max*0.09
+
+plot \
+'ajb.dat' using 3:($5/1000) title 'jitter' with linespoints lc "orange", \
+'ajb.dat' using 3:($7/1000) title 'avbuftime' with linespoints lc "skyblue", \
+'ajb.dat' using 3:($8/1000) title 'bufmin' with linespoints lc "sea-green", \
+'ajb.dat' using 3:($9/1000) title 'bufmax' with linespoints lc "sea-green", \
+'ajb.dat' using 3:($6/1000) title 'buftime' lc "light-grey", \
+'ajb.dat' using 3:(bufst($10)) title 'Low/High' lc "red", \
+"<echo 1 1 1" using (X_max):(bufst(2)):(text1(2)) notitle w labels tc  "red", \
+"<echo 1 1 1" using (X_max):(bufst(1)):(text1(1)) notitle w labels tc  "red", \
+'underrun.dat' using 3:(underr($4)) title 'underrun' pt 7 ps 1.5 lc "red", \
+"<echo 1 1 1" using (X_max):(underr(1)):(text2(1)) notitle w labels tc "red"

--- a/docs/aubuf/ajb.plot
+++ b/docs/aubuf/ajb.plot
@@ -1,0 +1,79 @@
+#!/usr/bin/gnuplot
+#
+# How to generate a plot
+# ======================
+# This gnuplot script plots DEBUG_LEVEL 6 output of ajb.c. You have to
+# increment the DEBUG_LEVEL in ajb.c if you want to get the table for
+# ajb.dat. Then call baresip like this:
+#
+# ./baresip 2>&1 | grep -Eo "plot_ajb.*" > ajb.dat
+#
+# Call this script. Then compare the plot legend with the variables in ajb.c!
+#
+#
+# Description of the plot
+# =======================
+# The plot is a time based diagram. The values avbuftime should lie between
+# bufmin and bufmax. If it runs somewhere out of these boundaries a "Low" /
+# "High" situation is detected.
+#
+# "Good" means: The number of frames in the audio buffer is ok.
+#
+# "Low" means:  The number is too low. Then the number of frames are
+#               incremented by holding one frame back.
+#
+# "High" means: The number is to high. Then one frame is dropped. This reduces
+#               the audio delay.
+#
+# The number of "Low"/"High" situations should be low while buffer under-runs
+# should be avoided completely.
+
+# On the x-axes of the plot there is the time in milliseconds. See function
+# `ajb_calc()`! We note the variables in ajb.c here in parentheses.
+#  E.g. (var jitter).
+#
+# - The orange line is the computed network jitter (var jitter). This is a
+#   moving average of the difference (var d) between the real time diff
+#   (var tr - var tr0) and the RTP timestamps diff (var ts - var ts0).
+#   See RFC-3550 RTP - A.8!
+#   We suggest a fast rise of the moving average and a slow shrink. Thus
+#   avoiding buffer under-runs have a higher priority than reducing the audio
+#   delay.
+#
+# - The buftime (var buftime) is the whole time period stored in the aubuf.
+#   The buftime (light-grey) changes very fast during periods of jitter. To be
+#   applicable for detecting "Low" or "High" situations it has to be smoothed.
+#   The blue line avbuftime (var avbuftime) is a moving average of the buftime
+#   and is used to detect "Low"/"High". Thus the ajb algorithm tries to keep
+#   the avbuftime between the following boundaries.
+#
+# - The green lines bufmin and bufmax (var bufmin, bufmax) are boundaries for
+#   avbuftime.They are computed by constant factors (> 1.) from the jitter.
+#
+#
+# Copyright (C) 2020,2022 commend.com - Christian Spielberger, Michael Peitler
+
+
+# Choose your preferred gnuplot terminal or use e.g. evince to view the
+# ajb.eps!
+
+#set terminal x11
+set terminal postscript eps size 15,10 enhanced color
+set output 'ajb.eps'
+#set terminal png size 1280,480
+#set output 'ajb.png'
+set datafile separator ","
+set key outside
+set xlabel "time/[ms]"
+set ylabel "[ms]"
+plot \
+'ajb.dat' using 3:($5/1000) title 'jitter' with linespoints linecolor "orange", \
+'ajb.dat' using 3:($7/1000) title 'avbuftime' with linespoints linecolor "skyblue", \
+'ajb.dat' using 3:($8/1000) title 'bufmin' with linespoints linecolor "sea-green", \
+'ajb.dat' using 3:($9/1000) title 'bufmax' with linespoints linecolor "sea-green", \
+'ajb.dat' using 3:($10*10) title 'Good/Empty/Low/High' linecolor "red", \
+'ajb.dat' using 3:($6/1000) title 'buftime' linecolor "light-grey", \
+10 title "Empty=10" linecolor "red", \
+20 title "Low=20" linecolor "red", \
+30 title "High=30" linecolor "red"
+

--- a/docs/aubuf/config
+++ b/docs/aubuf/config
@@ -5,8 +5,8 @@ audio_alert		pulse,
 audio_level		no
 audio_buffer   20-160
 
-jitter_buffer_type	fixed		# off, fixed, adaptive
-jitter_buffer_delay	2-3
+jitter_buffer_type	minimize
+jitter_buffer_delay	0-5
 
 module_path		/usr/local/lib/baresip/modules
 

--- a/docs/aubuf/config
+++ b/docs/aubuf/config
@@ -5,7 +5,7 @@ audio_alert		pulse,
 audio_level		no
 audio_buffer   20-160
 
-jitter_buffer_type	minimize
+jitter_buffer_type	adaptive
 jitter_buffer_delay	0-5
 
 module_path		/usr/local/lib/baresip/modules

--- a/docs/aubuf/config
+++ b/docs/aubuf/config
@@ -1,0 +1,53 @@
+#audio_path		/usr/local/share/baresip
+audio_player		pulse,
+audio_source		pulse,
+audio_alert		pulse,
+audio_level		no
+audio_buffer   20-160
+
+jitter_buffer_type	fixed		# off, fixed, adaptive
+jitter_buffer_delay	2-3
+
+module_path		/usr/local/lib/baresip/modules
+
+# UI Modules
+module			stdio.so
+module			cons.so
+
+module			opus.so
+#module			g722.so
+#module			g711.so
+
+module			auconv.so
+module			auresamp.so
+
+module			alsa.so
+module			pulse.so
+module			pulse_async.so
+
+
+module_app		account.so
+module_app		menu.so
+module_app		netroam.so
+
+
+cons_listen		0.0.0.0:5555 # cons - Console UI UDP/TCP sockets
+
+# Opus codec parameters
+opus_bitrate		28000 # 6000-510000
+#opus_stereo		yes
+#opus_sprop_stereo	yes
+#opus_cbr		no
+#opus_inbandfec		no
+#opus_dtx		no
+#opus_mirror		no
+#opus_complexity	10
+#opus_application	audio	# {voip,audio}
+#opus_samplerate	48000
+#opus_packet_loss	10	# 0-100 percent (expected packet loss)
+
+# Opus Multistream codec parameters
+#opus_ms_channels	2	#total channels (2 or 4)
+#opus_ms_streams	2	#number of streams
+#opus_ms_c_streams	2	#number of coupled streams
+

--- a/docs/aubuf/generate_plots.sh
+++ b/docs/aubuf/generate_plots.sh
@@ -4,6 +4,7 @@
 #netif=eno1
 target=10.1.0.215
 netif=enp8s0
+once=true
 
 function init_jitter () {
     sudo ip link add ifb1 type ifb || :
@@ -68,5 +69,9 @@ for ptime in 20 10 5 15 30 40; do
         ./ajb.plot
         cp ajb.eps ~/commend/baresip/aubuf/plots/ptime${i}_${ptime}_buf_${buf}_jitter_0.eps
         i=$(( i+1 ))
+
+        if [ $once == "true" ]; then
+            exit 0
+        fi
     done
 done

--- a/docs/aubuf/generate_plots.sh
+++ b/docs/aubuf/generate_plots.sh
@@ -33,7 +33,7 @@ function cleanup_jitter() {
     sudo ip link delete ifb1
 }
 
-trap "disable_jitter; cleanup_jitter" EXIT
+trap "disable_jitter; cleanup_jitter; killall -q baresip" EXIT
 
 init_jitter
 

--- a/docs/aubuf/generate_plots.sh
+++ b/docs/aubuf/generate_plots.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-target=192.168.110.192
-netif=eno1
+#target=192.168.110.192
+#netif=eno1
+target=10.1.0.215
+netif=enp8s0
 
 function init_jitter () {
     sudo ip link add ifb1 type ifb || :

--- a/docs/aubuf/generate_plots.sh
+++ b/docs/aubuf/generate_plots.sh
@@ -40,11 +40,10 @@ for ptime in 20 10 5 15 30 40; do
 
     sed -e "s/ptime=[0-9]*/ptime=$ptime/" -i accounts
     for buf in $ptime $(( 2*ptime )) $(( 3*ptime )) $(( 4*ptime )) $(( 6*ptime )); do
-#    for buf in $(( 3*ptime )) $(( 4*ptime )) $(( 6*ptime )); do
         echo "########### ptime $ptime buffer $buf ###############"
 
         sed -e "s/audio_buffer\s*[0-9]*\-.*/audio_buffer   $buf-160/" -i config
-        baresip -f . > /tmp/b.log &
+        baresip -f . > /tmp/b.log 2>&1 &
         sleep 1
         echo "/dial $target" | nc -N localhost 5555
 
@@ -69,5 +68,3 @@ for ptime in 20 10 5 15 30 40; do
         i=$(( i+1 ))
     done
 done
-
-cleanup_jitter

--- a/docs/aubuf/generate_plots.sh
+++ b/docs/aubuf/generate_plots.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+target=192.168.110.192
+netif=eno1
+
+function init_jitter () {
+    sudo ip link add ifb1 type ifb || :
+    sudo ip link set ifb1 up
+    sudo tc qdisc add dev $netif handle ffff: ingress
+    sudo tc filter add dev $netif parent ffff: u32 match u32 0 0 action mirred egress redirect dev ifb1
+}
+
+
+function enable_jitter() {
+    echo "ENABLE JITTER ..."
+    sudo tc qdisc add dev ifb1 root netem delay 100ms 50ms
+}
+
+
+function disable_jitter() {
+    echo "DISABLE JITTER ..."
+    sudo tc qdisc del dev ifb1 root
+}
+
+
+function cleanup_jitter() {
+    echo "CLEANUP jitter"
+    sudo tc filter delete dev $netif parent ffff:
+    sudo tc qdisc delete dev $netif ingress
+    sudo ip link set ifb1 down
+    sudo ip link delete ifb1
+}
+
+trap "disable_jitter; cleanup_jitter" EXIT
+
+init_jitter
+
+i=1
+for ptime in 20 10 5 15 30 40; do
+
+    sed -e "s/ptime=[0-9]*/ptime=$ptime/" -i accounts
+    for buf in $ptime $(( 2*ptime )) $(( 3*ptime )) $(( 4*ptime )) $(( 6*ptime )); do
+#    for buf in $(( 3*ptime )) $(( 4*ptime )) $(( 6*ptime )); do
+        echo "########### ptime $ptime buffer $buf ###############"
+
+        sed -e "s/audio_buffer\s*[0-9]*\-.*/audio_buffer   $buf-160/" -i config
+        baresip -f . > /tmp/b.log &
+        sleep 1
+        echo "/dial $target" | nc -N localhost 5555
+
+        sleep 8
+
+        enable_jitter
+
+        sleep $(( ptime ))
+
+        disable_jitter
+
+        sleep $(( ptime ))
+
+        echo "/quit" | nc -N localhost 5555
+
+        sleep 1
+
+        grep -Eo "plot_ajb.*" /tmp/b.log  > ajb.dat
+        grep -Eo "plot_underrun.*" /tmp/b.log  > underrun.dat
+        ./ajb.plot
+        cp ajb.eps ~/commend/baresip/aubuf/plots/ptime${i}_${ptime}_buf_${buf}_jitter_0.eps
+        i=$(( i+1 ))
+    done
+done
+
+cleanup_jitter

--- a/include/rem_aubuf.h
+++ b/include/rem_aubuf.h
@@ -22,6 +22,7 @@ int  aubuf_get(struct aubuf *ab, uint32_t ptime, uint8_t *p, size_t sz);
 void aubuf_flush(struct aubuf *ab);
 int  aubuf_debug(struct re_printf *pf, const struct aubuf *ab);
 size_t aubuf_cur_size(const struct aubuf *ab);
+void aubuf_drop_auframe(struct aubuf *ab, struct auframe *af);
 
 static inline int aubuf_write(struct aubuf *ab, const uint8_t *p, size_t sz)
 {

--- a/include/rem_aubuf.h
+++ b/include/rem_aubuf.h
@@ -5,7 +5,13 @@
  */
 struct aubuf;
 
+enum aubuf_mode {
+	AUBUF_FIXED,
+	AUBUF_ADAPTIVE
+};
+
 int  aubuf_alloc(struct aubuf **abp, size_t min_sz, size_t max_sz);
+void aubuf_set_mode(struct aubuf *ab, enum aubuf_mode mode);
 int  aubuf_resize(struct aubuf *ab, size_t min_sz, size_t max_sz);
 int  aubuf_write_auframe(struct aubuf *ab, struct auframe *af);
 int  aubuf_append_auframe(struct aubuf *ab, struct mbuf *mb,

--- a/include/rem_aubuf.h
+++ b/include/rem_aubuf.h
@@ -12,6 +12,7 @@ enum aubuf_mode {
 
 int  aubuf_alloc(struct aubuf **abp, size_t min_sz, size_t max_sz);
 void aubuf_set_mode(struct aubuf *ab, enum aubuf_mode mode);
+void aubuf_set_silence(struct aubuf *ab, double silence);
 int  aubuf_resize(struct aubuf *ab, size_t min_sz, size_t max_sz);
 int  aubuf_write_auframe(struct aubuf *ab, struct auframe *af);
 int  aubuf_append_auframe(struct aubuf *ab, struct mbuf *mb,

--- a/include/rem_auframe.h
+++ b/include/rem_auframe.h
@@ -42,3 +42,4 @@ static inline void auframe_update(struct auframe *af, void *sampv,
 size_t auframe_size(const struct auframe *af);
 void   auframe_mute(struct auframe *af);
 double auframe_level(struct auframe *af);
+bool   auframe_silence(struct auframe *af);

--- a/include/rem_auframe.h
+++ b/include/rem_auframe.h
@@ -42,4 +42,3 @@ static inline void auframe_update(struct auframe *af, void *sampv,
 size_t auframe_size(const struct auframe *af);
 void   auframe_mute(struct auframe *af);
 double auframe_level(struct auframe *af);
-bool   auframe_silence(struct auframe *af);

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -278,7 +278,7 @@ enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af)
 	if (!ajb->avbuftime)
 		goto out;
 
-	if (ajb->as == AJB_GOOD || !auframe_silence(af))
+	if (ajb->as == AJB_GOOD)
 		goto out;
 
 	as = ajb->as;

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -1,0 +1,263 @@
+/**
+ * @file ajb.c  Adaptive Jitter Buffer algorithm
+ *
+ * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
+ */
+#include <stdlib.h>
+#include <re.h>
+#include <rem_au.h>
+#include <rem_auframe.h>
+#include <rem_aubuf.h>
+#include "ajb.h"
+
+#define DEBUG_LEVEL 6
+
+/**
+ * @brief The adaptive jitter computation is done by means of an exponential
+ * moving average (EMA).
+ *￼j_i = j_{i-1} + a (c - j_{i-1})
+ *
+ * Where $a$ ist the EMA coefficient and $c$ is the current value.
+ */
+enum {
+	JITTER_EMA_COEFF   = 512,  /* Divisor for jitter EMA coefficient */
+	JITTER_UP_SPEED    = 64,   /* 64 times faster up than down       */
+	BUFTIME_EMA_COEFF  = 128,  /* Divisor for Buftime EMA coeff.     */
+	BUFTIME_LO         = 125,  /* 125% of jitter                     */
+	BUFTIME_HI         = 200,  /* 200% of jitter                     */
+};
+
+
+/** Adaptive jitter buffer statistics */
+struct ajb {
+	int32_t jitter;      /**< Jitter in [us]                  */
+	struct lock *lock;
+
+	uint32_t ts0;        /**< previous timestamp              */
+	uint64_t tr0;        /**< previous time of arrival        */
+#if DEBUG_LEVEL >= 6
+	uint64_t tr00;       /**< arrival of first packet         */
+	struct {
+		int32_t d;
+		uint32_t buftime;
+		uint32_t bufmin;
+		uint32_t bufmax;
+	} plot;
+#endif
+
+	enum ajb_state as;    /**< computed jitter buffer state    */
+
+	uint32_t ptime;      /**< Packet time [us]                */
+	int32_t avbuftime;   /**< average buffered time [us]      */
+	bool started;        /**< Started flag                    */
+};
+
+
+static void destructor(void *arg)
+{
+	struct ajb *ajb = arg;
+
+	mem_deref(ajb->lock);
+}
+
+
+#if DEBUG_LEVEL >= 6
+static void plot_ajb(struct ajb *ajb, uint64_t tr)
+{
+	uint32_t treal;
+
+	if (!ajb->tr00)
+		ajb->tr00 = tr;
+
+	treal = (uint32_t) (tr - ajb->tr00);
+	re_printf("%s, 0x%p, %u, %i, %u, %u, %u, %i, %i, %u\n",
+			__func__,               /* row 1  - grep */
+			ajb,                    /* row 2  - grep optional */
+			treal,                  /* row 3  - plot optional */
+			ajb->plot.d,            /* row 4  - plot */
+			ajb->jitter,            /* row 5  - plot */
+			ajb->plot.buftime,      /* row 6  - plot */
+			ajb->avbuftime,         /* row 7  - plot */
+			ajb->plot.bufmin,       /* row 8  - plot */
+			ajb->plot.bufmax,       /* row 9  - plot */
+			ajb->as);               /* row 10 - plot */
+}
+#endif
+
+/**
+ * Initializes the adaptive jitter buffer statistics
+ *
+ * @param ajb    Adaptive jitter buffer statistics
+ */
+struct ajb *ajb_alloc(void)
+{
+	struct ajb *ajb;
+	int err;
+
+	ajb = mem_zalloc(sizeof(*ajb), destructor);
+	if (!ajb)
+		return NULL;
+
+	err = lock_alloc(&ajb->lock);
+	if (err)
+		goto out;
+
+	ajb->ts0 = 0;
+	ajb->tr0 = 0;
+	ajb->as = AJB_GOOD;
+
+out:
+	if (err)
+		ajb = mem_deref(ajb);
+
+	return ajb;
+}
+
+
+void ajb_reset(struct ajb *ajb)
+{
+	if (!ajb)
+		return;
+
+	lock_write_get(ajb->lock);
+	ajb->ts0 = 0;
+	ajb->tr0 = 0;
+
+	/* We start with wish size. */
+	ajb->started = false;
+	ajb->as = AJB_GOOD;
+	lock_rel(ajb->lock);
+}
+
+
+/**
+ * Computes the jitter for audio frame arrival.
+ *
+ * @param ajb     Adaptive jitter buffer statistics
+ * @param af      Audio frame
+ * @param cur_sz  Current aubuf size
+ */
+void ajb_calc(struct ajb *ajb, struct auframe *af, size_t cur_sz)
+{
+	uint64_t tr;                       /**< Real time in [us]            */
+	uint32_t buftime, bufmax, bufmin;  /**< Buffer time in [us]          */
+	int32_t d;                         /**< Time shift in [us]           */
+	int32_t da;                        /**< Absolut time shift in [us]   */
+	int32_t s;                         /**< EMA coefficient              */
+	int64_t ts;                        /**< Time stamp                   */
+	uint32_t tsd;                      /**< Time stamp divisor           */
+	size_t sz;
+
+
+	if (!ajb || !af || !af->srate)
+		return;
+
+	lock_write_get(ajb->lock);
+	sz = aufmt_sample_size(af->fmt);
+	ts = (int64_t) af->timestamp;
+	tr = tmr_jiffies_usec();
+	tsd = af->srate / 1000;
+	if (!ajb->ts0)
+		goto out;
+
+	d = (int32_t) ( ((int64_t) tr - (int64_t) ajb->tr0) -
+			(ts - (int64_t) ajb->ts0) * 1000 / tsd );
+
+	da = abs(d);
+
+	buftime = cur_sz / sz * 1000 * 1000 / af->srate;
+	if (ajb->started) {
+		ajb->avbuftime += ((int32_t) buftime - ajb->avbuftime) /
+				  BUFTIME_EMA_COEFF;
+		if (ajb->avbuftime < 0)
+			ajb->avbuftime = 0;
+	}
+	else {
+		/* Directly after "filling" of aubuf compute a good start value
+		 * fitting to wish size. */
+		ajb->avbuftime = buftime;
+		ajb->jitter = ajb->avbuftime * 100 * 2 /
+			(BUFTIME_LO + BUFTIME_HI);
+		ajb->started = true;
+	}
+
+	if (!ajb->ptime)
+		goto out;
+
+	s = da > ajb->jitter ? JITTER_UP_SPEED : 1;
+
+	ajb->jitter += (da - ajb->jitter) * s / JITTER_EMA_COEFF;
+	if (ajb->jitter < 0)
+		ajb->jitter = 0;
+
+	bufmin = (uint32_t) ajb->jitter * BUFTIME_LO / 100;
+	bufmax = (uint32_t) ajb->jitter * BUFTIME_HI / 100;
+
+	bufmin = MAX(bufmin, ajb->ptime * 2 / 3);
+	bufmax = MAX(bufmax, bufmin + 4 * ajb->ptime / 3);
+
+	if ((uint32_t) ajb->avbuftime < bufmin)
+		ajb->as = AJB_LOW;
+	else if ((uint32_t) ajb->avbuftime > bufmax)
+		ajb->as = AJB_HIGH;
+	else
+		ajb->as = AJB_GOOD;
+
+#if DEBUG_LEVEL >= 6
+	ajb->plot.d = d;
+	ajb->plot.buftime = buftime;
+	ajb->plot.bufmin  = bufmin;
+	ajb->plot.bufmax  = bufmax;
+	plot_ajb(ajb, tr / 1000);
+#endif
+out:
+	lock_rel(ajb->lock);
+	ajb->ts0 = ts;
+	ajb->tr0 = tr;
+}
+
+
+enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af)
+{
+	enum ajb_state as;
+
+	if (!ajb || !af || !af->srate || !af->sampc)
+		return AJB_GOOD;
+
+	lock_write_get(ajb->lock);
+
+	/* ptime in [us] */
+	ajb->ptime = af->sampc * 1000 * 1000 / af->srate;
+	as = ajb->as;
+	if (!ajb->avbuftime)
+		goto out;
+
+	if (as == AJB_HIGH) {
+		/* early adjustment of avbuftime */
+		ajb->avbuftime -= ajb->ptime;
+		ajb->as = AJB_GOOD;
+	}
+	else if (as == AJB_LOW) {
+		/* early adjustment */
+		ajb->avbuftime += ajb->ptime;
+		ajb->as = AJB_GOOD;
+	}
+
+out:
+	lock_rel(ajb->lock);
+	return as;
+}
+
+
+int32_t ajb_debug(const struct ajb *ajb)
+{
+	int32_t jitter;
+
+	lock_write_get(ajb->lock);
+	jitter = ajb ? ajb->jitter : 0;
+	lock_rel(ajb->lock);
+	re_printf("jitter: %d, avbuftime: %d\n",
+		  ajb->jitter / 1000, ajb->avbuftime);
+
+	return jitter;
+}

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -35,8 +35,8 @@ struct ajb {
 
 	uint32_t ts0;        /**< previous timestamp              */
 	uint64_t tr0;        /**< previous time of arrival        */
-#if DEBUG_LEVEL >= 6
 	uint64_t tr00;       /**< arrival of first packet         */
+#if DEBUG_LEVEL >= 6
 	struct {
 		int32_t d;
 		uint32_t buftime;

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <re.h>
 #include <rem_au.h>
+#include <rem_aulevel.h>
 #include <rem_auframe.h>
 #include <rem_aubuf.h>
 #include "ajb.h"

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -55,6 +55,7 @@ struct ajb {
 	uint32_t bufmin;     /**< Minimum buffer time [us]        */
 	struct auframe af;   /**< Audio frame of last ajb_get()   */
 	uint32_t dropped;    /**< Dropped audio frames counter    */
+	double silence;      /**< Silence audio level             */
 };
 
 
@@ -115,7 +116,7 @@ void plot_underrun(struct ajb *ajb)
  *
  * @param ajb    Adaptive jitter buffer statistics
  */
-struct ajb *ajb_alloc(void)
+struct ajb *ajb_alloc(double silence)
 {
 	struct ajb *ajb;
 	int err;
@@ -131,6 +132,7 @@ struct ajb *ajb_alloc(void)
 	ajb->ts0 = 0;
 	ajb->tr0 = 0;
 	ajb->as = AJB_GOOD;
+	ajb->silence = silence;
 
 out:
 	if (err)
@@ -278,7 +280,7 @@ enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af)
 	if (!ajb->avbuftime)
 		goto out;
 
-	if (ajb->as == AJB_GOOD)
+	if (ajb->as == AJB_GOOD || auframe_level(af) > ajb->silence)
 		goto out;
 
 	as = ajb->as;

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -301,10 +301,3 @@ int32_t ajb_debug(const struct ajb *ajb)
 
 	return jitter;
 }
-
-
-uint32_t ajb_bufmin(struct ajb *ajb)
-{
-	size_t sz = aufmt_sample_size(ajb->af.fmt);
-	return ajb->bufmin / 1000 * ajb->af.sampc * sz / 1000;
-}

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -33,7 +33,7 @@ struct ajb {
 	int32_t jitter;      /**< Jitter in [us]                  */
 	struct lock *lock;
 
-	uint32_t ts0;        /**< previous timestamp              */
+	uint64_t ts0;        /**< previous timestamp              */
 	uint64_t tr0;        /**< previous time of arrival        */
 	uint64_t tr00;       /**< arrival of first packet         */
 #if DEBUG_LEVEL >= 6
@@ -189,7 +189,8 @@ void ajb_calc(struct ajb *ajb, struct auframe *af, size_t cur_sz)
 
 	da = abs(d);
 
-	buftime = cur_sz * 1000 / (af->srate * af->ch *  sz / 1000);
+	buftime = (uint32_t) (cur_sz * 1000 /
+			      (af->srate * af->ch *  sz / 1000));
 	if (ajb->started) {
 		ajb->avbuftime += ((int32_t) buftime - ajb->avbuftime) /
 				  BUFTIME_EMA_COEFF;
@@ -253,7 +254,7 @@ enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af)
 	ajb->af = *af;
 
 	/* ptime in [us] */
-	ajb->ptime = af->sampc * 1000 * 1000 / af->srate;
+	ajb->ptime = (uint32_t) (af->sampc * 1000 * 1000 / af->srate);
 	if (!ajb->avbuftime)
 		goto out;
 

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -280,7 +280,8 @@ enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af)
 	if (!ajb->avbuftime)
 		goto out;
 
-	if (ajb->as == AJB_GOOD || auframe_level(af) > ajb->silence)
+	if (ajb->as == AJB_GOOD ||
+	    (ajb->silence < 0. && auframe_level(af) > ajb->silence))
 		goto out;
 
 	as = ajb->as;

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -10,7 +10,7 @@
 #include <rem_aubuf.h>
 #include "ajb.h"
 
-#define DEBUG_LEVEL 6
+#define DEBUG_LEVEL 5
 
 /**
  * @brief The adaptive jitter computation is done by means of an exponential

--- a/src/aubuf/ajb.h
+++ b/src/aubuf/ajb.h
@@ -1,0 +1,21 @@
+/**
+ * @file ajb.h  Adaptive Jitter Buffer interface
+ *
+ * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
+ */
+
+
+enum ajb_state {
+	AJB_GOOD = 0,
+	AJB_EMPTY,
+	AJB_LOW,
+	AJB_HIGH,
+};
+
+struct ajb;
+
+struct ajb *ajb_alloc(void);
+void ajb_reset(struct ajb *ajb);
+void ajb_calc(struct ajb *ajb, struct auframe *af, size_t sampc);
+enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af);
+int32_t ajb_debug(const struct ajb *ajb);

--- a/src/aubuf/ajb.h
+++ b/src/aubuf/ajb.h
@@ -13,7 +13,7 @@ enum ajb_state {
 
 struct ajb;
 
-struct ajb *ajb_alloc(void);
+struct ajb *ajb_alloc(double silence);
 void ajb_reset(struct ajb *ajb);
 void ajb_calc(struct ajb *ajb, struct auframe *af, size_t sampc);
 enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af);

--- a/src/aubuf/ajb.h
+++ b/src/aubuf/ajb.h
@@ -7,7 +7,6 @@
 
 enum ajb_state {
 	AJB_GOOD = 0,
-	AJB_EMPTY,
 	AJB_LOW,
 	AJB_HIGH,
 };
@@ -19,3 +18,5 @@ void ajb_reset(struct ajb *ajb);
 void ajb_calc(struct ajb *ajb, struct auframe *af, size_t sampc);
 enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af);
 int32_t ajb_debug(const struct ajb *ajb);
+void plot_underrun(struct ajb *ajb);
+uint32_t ajb_bufmin(struct ajb *ajb);

--- a/src/aubuf/ajb.h
+++ b/src/aubuf/ajb.h
@@ -19,4 +19,3 @@ void ajb_calc(struct ajb *ajb, struct auframe *af, size_t sampc);
 enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af);
 int32_t ajb_debug(const struct ajb *ajb);
 void plot_underrun(struct ajb *ajb);
-uint32_t ajb_bufmin(struct ajb *ajb);

--- a/src/aubuf/ajb.h
+++ b/src/aubuf/ajb.h
@@ -19,3 +19,4 @@ void ajb_calc(struct ajb *ajb, struct auframe *af, size_t sampc);
 enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af);
 int32_t ajb_debug(const struct ajb *ajb);
 void plot_underrun(struct ajb *ajb);
+void ajb_drop(struct ajb *ajb, struct auframe *af);

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -232,8 +232,8 @@ int aubuf_append_auframe(struct aubuf *ab, struct mbuf *mb, struct auframe *af)
 	if (ab->max_sz && ab->cur_sz > ab->max_sz) {
 #if AUBUF_DEBUG
 		++ab->stats.or;
-		(void)re_printf("aubuf: %p overrun (cur=%zu)\n",
-				ab, ab->cur_sz);
+		(void)re_printf("aubuf: %p overrun (cur=%zu)\n", ab,
+				ab->cur_sz);
 #endif
 		f = list_ledata(ab->afl.head);
 		if (f) {
@@ -317,7 +317,9 @@ void aubuf_read_auframe(struct aubuf *ab, struct auframe *af)
 	lock_write_get(ab->lock);
 	as = ajb_get(ab->ajb, af);
 	if (as == AJB_LOW) {
-		re_printf("aubuf: inc buffer due to high jitter\n");
+#ifdef AUBUF_DEBUG
+		(void)re_printf("aubuf: inc buffer due to high jitter\n");
+#endif
 		ajb_debug(ab->ajb);
 		goto out;
 	}
@@ -341,7 +343,9 @@ void aubuf_read_auframe(struct aubuf *ab, struct auframe *af)
 
 	read_auframe(ab, af);
 	if (as == AJB_HIGH) {
-		re_printf("aubuf: drop a frame to reduce latency\n");
+#ifdef AUBUF_DEBUG
+		(void)re_printf("aubuf: drop a frame to reduce latency\n");
+#endif
 		ajb_debug(ab->ajb);
 		read_auframe(ab, af);
 	}

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -34,6 +34,7 @@ struct aubuf {
 #endif
 	enum aubuf_mode mode;
 	struct ajb *ajb;         /**< Adaptive jitter buffer statistics      */
+	double silence;          /**< Silence volume in negative [dB]        */
 };
 
 
@@ -146,6 +147,21 @@ void aubuf_set_mode(struct aubuf *ab, enum aubuf_mode mode)
 		return;
 
 	ab->mode = mode;
+}
+
+
+/**
+ * Sets the volume level for silence
+ *
+ * @param ab       Audio buffer
+ * @param silence  Volume level in negative [dB]
+ */
+void aubuf_set_silence(struct aubuf *ab, double silence)
+{
+	if (!ab)
+		return;
+
+	ab->silence = silence;
 }
 
 
@@ -296,7 +312,7 @@ void aubuf_read_auframe(struct aubuf *ab, struct auframe *af)
 		return;
 
 	if (!ab->ajb && ab->mode == AUBUF_ADAPTIVE)
-		ab->ajb = ajb_alloc();
+		ab->ajb = ajb_alloc(ab->silence);
 
 	lock_write_get(ab->lock);
 	as = ajb_get(ab->ajb, af);

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -463,3 +463,9 @@ void aubuf_sort_auframe(struct aubuf *ab)
 {
 	list_sort(&ab->afl, frame_less_equal, NULL);
 }
+
+
+void aubuf_drop_auframe(struct aubuf *ab, struct auframe *af)
+{
+	ajb_drop(ab->ajb, af);
+}

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -12,7 +12,7 @@
 #include "ajb.h"
 
 
-#define AUBUF_DEBUG 0
+#define AUBUF_DEBUG 1
 #define AUDIO_TIMEBASE 1000000U
 
 
@@ -33,7 +33,7 @@ struct aubuf {
 	} stats;
 #endif
 	enum aubuf_mode mode;
-	struct ajb *ajb;         /**< Adaptive jitter buffer statistics       */
+	struct ajb *ajb;         /**< Adaptive jitter buffer statistics      */
 };
 
 
@@ -69,7 +69,7 @@ static void read_auframe(struct aubuf *ab, struct auframe *af)
 	size_t sample_size = aufmt_sample_size(af->fmt);
 	size_t sz = auframe_size(af);
 	uint8_t *p = af->sampv;
-	
+
 	while (le) {
 		struct frame *f = le->data;
 		size_t n;
@@ -313,6 +313,7 @@ void aubuf_read_auframe(struct aubuf *ab, struct auframe *af)
 			++ab->stats.ur;
 			(void)re_printf("aubuf: %p underrun (cur=%zu)\n",
 					ab, ab->cur_sz);
+			plot_underrun(ab->ajb);
 		}
 #endif
 		filling = ab->filling;
@@ -323,7 +324,7 @@ void aubuf_read_auframe(struct aubuf *ab, struct auframe *af)
 	}
 
 	read_auframe(ab, af);
-	if (as == AJB_HIGH && auframe_silence(af)) {
+	if (as == AJB_HIGH) {
 		re_printf("aubuf: drop a frame to reduce latency\n");
 		ajb_debug(ab->ajb);
 		read_auframe(ab, af);

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -12,7 +12,7 @@
 #include "ajb.h"
 
 
-#define AUBUF_DEBUG 1
+#define AUBUF_DEBUG 0
 #define AUDIO_TIMEBASE 1000000U
 
 

--- a/src/aubuf/mod.mk
+++ b/src/aubuf/mod.mk
@@ -4,4 +4,4 @@
 # Copyright (C) 2010 Creytiv.com
 #
 
-SRCS	+= aubuf/aubuf.c
+SRCS	+= aubuf/aubuf.c aubuf/ajb.c

--- a/src/auframe/auframe.c
+++ b/src/auframe/auframe.c
@@ -105,20 +105,3 @@ double auframe_level(struct auframe *af)
 
 	return af->level;
 }
-
-
-/**
- * Computes audio frame volume and compares with a boundary to decide if it is
- * nearly silence
- *
- * @param af  Audio frame
- *
- * @return true if the frame is nearly silence
- */
-bool auframe_silence(struct auframe *af)
-{
-	/* TODO: A good value for silence if not s16le. */
-	/*       It should be not too low. Otherwise ajb will be
-	 *       blocked.                               */
-	return auframe_level(af) < -70.;
-}

--- a/src/auframe/auframe.c
+++ b/src/auframe/auframe.c
@@ -11,10 +11,6 @@
 #include <rem_auframe.h>
 
 
-enum {
-	SILENCE_Q = 1024 * 1024,  /* Quadratic sample value for silence */
-};
-
 /**
  * Initialize an audio frame
  *

--- a/src/auframe/auframe.c
+++ b/src/auframe/auframe.c
@@ -111,35 +111,14 @@ double auframe_level(struct auframe *af)
  * Computes audio frame volume and compares with a boundary to decide if it is
  * nearly silence
  *
- * Note: faster than auframe_level for s16le
- *   - no sqrt
- *   - no logarithm
- *   - early loop exit for non-silence
- *
  * @param af  Audio frame
  *
  * @return true if the frame is nearly silence
  */
 bool auframe_silence(struct auframe *af)
 {
-	const int16_t *v;
-	int32_t sum = 0;
-	size_t i;
-
-	if (af->fmt != AUFMT_S16LE) {
-		/* TODO: A good value for silence if not s16le. */
-		/*       It should be not too low. Otherwise ajb will be
-		 *       blocked.                               */
-		return auframe_level(af) < -70.;
-	}
-
-	v = af->sampv;
-	for (i = 0; i < af->sampc; i++) {
-		sum += v[i]*v[i];
-
-		if (sum > (int32_t) (i + 1) * SILENCE_Q)
-			return false;
-	}
-
-	return true;
+	/* TODO: A good value for silence if not s16le. */
+	/*       It should be not too low. Otherwise ajb will be
+	 *       blocked.                               */
+	return auframe_level(af) < -70.;
 }


### PR DESCRIPTION
This a rework on the adaptive jitter buffer algorithm in `re/src/jbuf`.
Discussion: https://github.com/baresip/re/discussions/184
Relates to https://github.com/baresip/baresip/pull/1784.

For G.711 the `jbuf` can be dropped (`jitter_buffer_type  off`). What means that each RTP packet is immediately passed to the decoder. The `aubuf` handles re-ordered audio frames.

For state-full codecs like G.722, opus the `jbuf` has a new option (`jitter_buffer_type  minimize`). In this case still `jbuf` has to handle re-ordered packets. But the `minimize` mode ensures that the `jbuf` latency is adjusted on the frequency of "packet to late" occurrences.

The `jitter_buffer_type  adaptive` becomes obsolete. --> Simplifies `re/src/jbuf/jbuf.c` and `baresip/src/audio.c`.

- aubuf: compute input jitter and increment/decrease buffered samples
- aubuf: add aubuf mode selection
- aubuf: add documentation for adaptive jitter buffer
- docs: add .gitignore to docs/aubuf
- aubuf: fixes
- docs/aubuf: add a script for plot generation
- docs/aubuf: activate new jbuf type "minimize" for plots
- aubuf: reset debug level

This image shows how starting with aubuf min size 60ms, the algorithm reduces the delay because of low jitter.
![aubuf1](https://user-images.githubusercontent.com/14180877/160774538-f2627fe5-3760-4e8e-bd50-cd964154ba12.png)

This image shows how the aubuf is adjusted to computed jitter. The network jitter simulation is activated at second 8 and disabled at second 27.
![aubuf2](https://user-images.githubusercontent.com/14180877/160775536-6306f0f6-d61e-414a-a401-1864260e8eee.png)
