### PR TITLE
ajb,aubuf: timestamp is given in [us]

### DIFF
--- a/docs/aubuf/.gitignore
+++ b/docs/aubuf/.gitignore
@@ -1,3 +1,5 @@
 ajb.dat
 ajb.eps
 underrun.dat
+plots
+ajb.json

--- a/docs/aubuf/generate_plots.sh
+++ b/docs/aubuf/generate_plots.sh
@@ -34,6 +34,11 @@ function cleanup_jitter() {
     sudo ip link delete ifb1
 }
 
+if ! which jq; then
+    echo "Install jq"
+    exit 1
+fi
+
 trap "disable_jitter; cleanup_jitter; killall -q baresip" EXIT
 
 init_jitter
@@ -64,8 +69,8 @@ for ptime in 20 10 5 15 30 40; do
 
         sleep 1
 
-        grep -Eo "plot_ajb.*" /tmp/b.log  > ajb.dat
-        grep -Eo "plot_underrun.*" /tmp/b.log  > underrun.dat
+        cat ajb.json | jq -r '.traceEvents[] | select (.ph == "P") | .args.line' > ajb.dat
+        cat ajb.json | jq -r '.traceEvents[] | select (.ph == "U") | .args.line' > underrun.dat
         ./ajb.plot
         if [ ! -d plots ]; then
             mkdir plots

--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -173,7 +173,6 @@ void ajb_calc(struct ajb *ajb, struct auframe *af, size_t cur_sz)
 	int32_t da;                        /**< Absolut time shift in [us]   */
 	int32_t s;                         /**< EMA coefficient              */
 	int64_t ts;                        /**< Time stamp                   */
-	uint32_t tsd;                      /**< Time stamp divisor           */
 	size_t sz;
 
 
@@ -184,12 +183,11 @@ void ajb_calc(struct ajb *ajb, struct auframe *af, size_t cur_sz)
 	sz = aufmt_sample_size(af->fmt);
 	ts = (int64_t) af->timestamp;
 	tr = tmr_jiffies_usec();
-	tsd = af->srate / 1000;
 	if (!ajb->ts0)
 		goto out;
 
 	d = (int32_t) ( ((int64_t) tr - (int64_t) ajb->tr0) -
-			(ts - (int64_t) ajb->ts0) * 1000 / tsd );
+			(ts - (int64_t) ajb->ts0) );
 
 	da = abs(d);
 

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -86,12 +86,13 @@ static void read_auframe(struct aubuf *ab, struct auframe *af)
 		af->ch	      = f->af.ch;
 		af->timestamp = f->af.timestamp;
 
-		if (af->srate && af->ch && sample_size)
-			f->af.timestamp += n * AUDIO_TIMEBASE /
-					   (af->srate * af->ch * sample_size);
-
-		if (!mbuf_get_left(f->mb))
+		if (!mbuf_get_left(f->mb)) {
 			mem_deref(f);
+		}
+		else if (af->srate && af->ch && sample_size) {
+			f->af.timestamp += n * AUDIO_TIMEBASE /
+				(af->srate * af->ch * sample_size);
+		}
 
 		if (n == sz)
 			break;


### PR DESCRIPTION
- In ajb.c change the timestamp unit from RTP timestamps (sample count) to [us]
  per sample.
- In aubuf.c adjust the timestamp for an audio frame only if there is partial
  read.
