### PR TITLE
aubuf overruns on startup

### DIFF
--- a/docs/aubuf/.gitignore
+++ b/docs/aubuf/.gitignore
@@ -3,3 +3,4 @@ ajb.eps
 underrun.dat
 plots
 ajb.json
+mcplots

--- a/docs/aubuf/generate_plots_multicast.sh
+++ b/docs/aubuf/generate_plots_multicast.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+target=192.168.110.192
+netif=eno1
+#target=10.1.0.215
+#netif=enp8s0
+#once=true
+
+function init_jitter () {
+    sudo ip link add ifb1 type ifb || :
+    sudo ip link set ifb1 up
+    sudo tc qdisc add dev $netif handle ffff: ingress
+    sudo tc filter add dev $netif parent ffff: u32 match u32 0 0 action mirred egress redirect dev ifb1
+}
+
+
+function enable_jitter() {
+    echo "ENABLE JITTER ..."
+    sudo tc qdisc add dev ifb1 root netem delay 100ms 50ms
+}
+
+
+function disable_jitter() {
+    echo "DISABLE JITTER ..."
+    sudo tc qdisc del dev ifb1 root
+}
+
+
+function cleanup_jitter() {
+    echo "CLEANUP jitter"
+    sudo tc filter delete dev $netif parent ffff:
+    sudo tc qdisc delete dev $netif ingress
+    sudo ip link set ifb1 down
+    sudo ip link delete ifb1
+}
+
+
+if ! which jq; then
+    echo "Install jq"
+    exit 1
+fi
+
+
+trap "disable_jitter; cleanup_jitter; killall -q baresip; kill $tid_fm4" EXIT
+
+init_jitter
+
+i=1
+for jbuf in 0 1 3 4; do
+    for buf in 20 40 60; do
+        echo "########### jbuf min $jbuf buffer $buf ###############"
+
+        sed -e "s/audio_buffer\s*[0-9]*\-.*/audio_buffer   $buf-160/" -i mcconfig/config
+        sed -e "s/multicast_jbuf_delay\s*[0-9]*\-.*/multicast_jbuf_delay   $jbuf-20/" -i mcconfig/config
+        baresip -f mcconfig > /tmp/b.log 2>&1 &
+
+        sleep 1.5
+
+        ./stream_fm4.sh &
+        pidfm4=$( pgrep -P $! )
+        echo "STARTED STREAM with PID $pidfm4"
+
+        sleep 8
+
+        enable_jitter
+
+        sleep 8
+        disable_jitter
+
+        sleep 16
+
+        kill $pidfm4
+
+        echo "/quit" | nc -N localhost 5555
+
+        sleep 1
+
+        cat ajb.json | jq -r '.traceEvents[] | select (.ph == "P") | .args.line' > ajb.dat
+        cat ajb.json | jq -r '.traceEvents[] | select (.ph == "U") | .args.line' > underrun.dat
+        ./ajb.plot
+        if [ ! -d mcplots ]; then
+            mkdir mcplots
+        fi
+        cp ajb.eps mcplots/jbuf${i}_min${jbuf}_buf_${buf}.eps
+        i=$(( i+1 ))
+
+        if [ "$once" == "true" ]; then
+            exit 0
+        fi
+    done
+done

--- a/docs/aubuf/mcconfig/accounts
+++ b/docs/aubuf/mcconfig/accounts
@@ -1,0 +1,1 @@
+<sip:alice@office>;regint=0;ptime=20

--- a/docs/aubuf/mcconfig/config
+++ b/docs/aubuf/mcconfig/config
@@ -1,0 +1,59 @@
+#audio_path		/usr/local/share/baresip
+audio_player		pulse,
+audio_source		pulse,
+audio_alert		pulse,
+audio_level		no
+audio_buffer   60-160
+audio_buffer_mode	adaptive
+audio_silence		0.0
+
+jitter_buffer_type	adaptive
+jitter_buffer_delay   0-20
+
+module_path		/usr/local/lib/baresip/modules
+
+# UI Modules
+module			stdio.so
+module			cons.so
+
+module			g722.so
+module			g711.so
+
+module			auconv.so
+module			auresamp.so
+
+module			alsa.so
+module			pulse.so
+module			pulse_async.so
+
+
+module_app		account.so
+module_app		menu.so
+module_app		netroam.so
+
+
+cons_listen		0.0.0.0:5555 # cons - Console UI UDP/TCP sockets
+
+# Opus codec parameters
+opus_bitrate		28000 # 6000-510000
+#opus_stereo		yes
+#opus_sprop_stereo	yes
+#opus_cbr		no
+#opus_inbandfec		no
+#opus_dtx		no
+#opus_mirror		no
+#opus_complexity	10
+#opus_application	audio	# {voip,audio}
+#opus_samplerate	48000
+#opus_packet_loss	10	# 0-100 percent (expected packet loss)
+
+# Opus Multistream codec parameters
+#opus_ms_channels	2	#total channels (2 or 4)
+#opus_ms_streams	2	#number of streams
+#opus_ms_c_streams	2	#number of coupled streams
+
+
+module_app		multicast.so
+multicast_jbuf_type	adaptive		# off, fixed, adaptive
+multicast_jbuf_delay   1-20
+multicast_listener	224.0.1.194:5004

--- a/docs/aubuf/stream_fm4.sh
+++ b/docs/aubuf/stream_fm4.sh
@@ -1,0 +1,1 @@
+gst-launch-1.0 -q --no-position souphttpsrc location=https://orf-live.ors-shoutcast.at/fm4-q1a ssl-strict=false ! decodebin expose-all-streams=false ! audiorate skip-to-first=true ! audioconvert ! audioresample ! avenc_g722 ! rtpg722pay ! udpsink host=224.0.1.194 port=5004

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -24,6 +24,7 @@ struct aubuf {
 	size_t cur_sz;
 	size_t max_sz;
 	bool filling;
+	bool started;
 	uint64_t ts;
 
 #if AUBUF_DEBUG
@@ -213,6 +214,7 @@ static bool frame_less_equal(struct le *le1, struct le *le2, void *arg)
 int aubuf_append_auframe(struct aubuf *ab, struct mbuf *mb, struct auframe *af)
 {
 	struct frame *f;
+	size_t max_sz;
 
 	if (!ab || !mb)
 		return EINVAL;
@@ -230,11 +232,14 @@ int aubuf_append_auframe(struct aubuf *ab, struct mbuf *mb, struct auframe *af)
 	list_insert_sorted(&ab->afl, frame_less_equal, NULL, &f->le, f);
 	ab->cur_sz += mbuf_get_left(mb);
 
-	if (ab->max_sz && ab->cur_sz > ab->max_sz) {
+	max_sz = ab->started ? ab->max_sz : ab->wish_sz + 1;
+	if (max_sz && ab->cur_sz > max_sz) {
 #if AUBUF_DEBUG
-		++ab->stats.or;
-		(void)re_printf("aubuf: %p overrun (cur=%zu/%zu)\n", ab,
-				ab->cur_sz, ab->max_sz);
+		if (ab->started) {
+			++ab->stats.or;
+			(void)re_printf("aubuf: %p overrun (cur=%zu/%zu)\n",
+					ab, ab->cur_sz, ab->max_sz);
+		}
 #endif
 		f = list_ledata(ab->afl.head);
 		if (f) {
@@ -342,6 +347,7 @@ void aubuf_read_auframe(struct aubuf *ab, struct auframe *af)
 			goto out;
 	}
 
+	ab->started = true;
 	read_auframe(ab, af);
 	if (as == AJB_HIGH) {
 #if AUBUF_DEBUG


### PR DESCRIPTION
For multicast listeners there had been overruns at startup of a stream because of late start of player thread. In order to make aubuf independent from start time relation between write and read threads a started flag was added.

- aubuf: add a started flag
- docs: add aubuf plots for multicast

Relates to https://github.com/baresip/retest/pull/64