### PR TITLE
aubuf: do not drop frames if max size was not set

### DIFF
--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -233,7 +233,7 @@ int aubuf_append_auframe(struct aubuf *ab, struct mbuf *mb, struct auframe *af)
 	ab->cur_sz += mbuf_get_left(mb);
 
 	max_sz = ab->started ? ab->max_sz : ab->wish_sz + 1;
-	if (max_sz && ab->cur_sz > max_sz) {
+	if (ab->max_sz && ab->cur_sz > max_sz) {
 #if AUBUF_DEBUG
 		if (ab->started) {
 			++ab->stats.or;


### PR DESCRIPTION
Zero max_sz means that there is no overrun check wanted. This is used in
baresip audio source modules like `aufile` and `gst` to read the whole file
into an aubuf before pushing to an audio player. Thus this commit fixes these
ausrc modules.
