### PR TITLE
aubuf: better support for different put/get ptime

### DIFF
--- a/docs/aubuf/ajb.plot
+++ b/docs/aubuf/ajb.plot
@@ -57,7 +57,7 @@
 # Choose your preferred gnuplot terminal or use e.g. evince to view the
 # ajb.eps!
 
-#set terminal x11
+#set terminal qt persist
 set terminal postscript eps size 15,10 enhanced color
 set output 'ajb.eps'
 #set terminal png size 1280,480

--- a/docs/aubuf/config
+++ b/docs/aubuf/config
@@ -1,9 +1,9 @@
 #audio_path		/usr/local/share/baresip
-audio_player		pulse,
-audio_source		pulse,
-audio_alert		pulse,
+audio_player		pulse_async,
+audio_source		pulse_async,
+audio_alert		pulse_async,
 audio_level		no
-audio_buffer   20-250
+audio_buffer   30-250
 audio_buffer_mode	adaptive
 audio_silence		0.0
 

--- a/docs/aubuf/generate_plots.sh
+++ b/docs/aubuf/generate_plots.sh
@@ -16,7 +16,7 @@ function init_jitter () {
 
 function enable_jitter() {
     echo "ENABLE JITTER ..."
-    sudo tc qdisc add dev ifb1 root netem delay 200ms 100ms
+    sudo tc qdisc add dev ifb1 root netem delay 0ms 150ms
 }
 
 
@@ -47,11 +47,11 @@ i=1
 for ptime in 20 10 5 15 30 40; do
 
     sed -e "s/ptime=[0-9]*/ptime=$ptime/" -i accounts
-    for buf in $ptime $(( 2*ptime )) $(( 3*ptime )) $(( 4*ptime )) $(( 6*ptime )); do
+    for buf in $(( ptime + ptime/2 )) $(( ptime )) $(( 2*ptime )) $(( 4*ptime )) $(( 6*ptime )); do
         echo "########### ptime $ptime buffer $buf ###############"
 
         sed -e "s/audio_buffer\s*[0-9]*\-.*/audio_buffer   $buf-250/" -i config
-        baresip -f . > /tmp/b.log 2>&1 &
+        baresip -v -f . > /tmp/b.log 2>&1 &
         sleep 1
         echo "/dial $target" | nc -N localhost 5555
 

--- a/src/aubuf/ajb.h
+++ b/src/aubuf/ajb.h
@@ -4,6 +4,7 @@
  * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
  */
 
+#define AUDIO_TIMEBASE 1000000U
 
 enum ajb_state {
 	AJB_GOOD = 0,


### PR DESCRIPTION
By default the ptime for writing frames to the aubuf is 20ms. If e.g. module
pulse_async is used the ptime for reading dynamically changes and lies around
5ms.

- Compute ptime for get/put separately, and consider channel number.
- Computed jitter was too low. Reset ts0 and tr0 only if a frame is missing.
- Support wish size values that are not a multiple of written frames, if read
  frames are smaller. This avoids underruns at the beginning of a stream.
     E.g.: 20ms frames are written, 5 ms are read and minimum size is set to 30ms.
     Then two calls to `aubuf_get()` after there are 20ms in the aubuf still return
      silence frames. The thirds `aubuf_get()` returns the first 5ms frame.
- Remove the +1 byte for max_sz. This makes no sense and no difference.

Tested with:
- pulse and pulse_async
- opus, g711, g722
- different aubuf min size
- with and without jitter simulation

Here a plot with pulse_async, opus and 30ms audio buffer. The account has `ptime=20ms` which is default. For the pulseaudio stream `minreq=5ms`.
![ptime1_20_buf_30_jitter_0](https://user-images.githubusercontent.com/14180877/174566440-926cf871-3ab3-443a-9f2e-c52a29bfb9f0.png)

