### PR TITLE
aubuf: the ajb mode should respect wish size

### DIFF
--- a/src/aubuf/ajb.h
+++ b/src/aubuf/ajb.h
@@ -14,7 +14,7 @@ enum ajb_state {
 
 struct ajb;
 
-struct ajb *ajb_alloc(double silence);
+struct ajb *ajb_alloc(double silence, size_t wish_sz);
 void ajb_reset(struct ajb *ajb);
 void ajb_calc(struct ajb *ajb, const struct auframe *af, size_t sampc);
 enum ajb_state ajb_get(struct ajb *ajb, struct auframe *af);

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -324,7 +324,7 @@ void aubuf_read_auframe(struct aubuf *ab, struct auframe *af)
 
 	sz = auframe_size(af);
 	if (!ab->ajb && ab->mode == AUBUF_ADAPTIVE)
-		ab->ajb = ajb_alloc(ab->silence);
+		ab->ajb = ajb_alloc(ab->silence, ab->wish_sz);
 
 	mtx_lock(ab->lock);
 	as = ajb_get(ab->ajb, af);


### PR DESCRIPTION
If `audio_buffer_type` is set to `adaptive` and the network does not jitter
noticeably but there might be very sporadic late audio frames then the wish
size can be increased by the user. What this commit does is to keep the average
buffer size between boundaries that respect the given wish size.
