### PR TITLE
make aubuf usage simpler

### DIFF
--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -244,7 +244,9 @@ void ajb_calc(struct ajb *ajb, const struct auframe *af, size_t cur_sz)
 
 	ptime = (uint32_t) (af->sampc * AUDIO_TIMEBASE / (af->srate * af->ch));
 	bufmin = MAX(bufmin, ptime * 2 / 3);
-	bufmin = MAX(bufmin, bufwish - ptime / 3);
+	if (bufwish >= ptime)
+		bufmin = MAX(bufmin, bufwish - ptime / 3);
+
 	bufmax = MAX(bufmax, bufmin + 7 * ptime / 6);
 
 	/* reset time base if a frame is missing */

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -23,7 +23,7 @@ struct aubuf {
 	size_t cur_sz;
 	size_t max_sz;
 	size_t fill_sz;         /**< To fill size                            */
-	size_t pkt_sz;        /**< Packet size                             */
+	size_t pkt_sz;          /**< Packet size                             */
 	bool started;
 	uint64_t ts;
 
@@ -118,7 +118,7 @@ int aubuf_alloc(struct aubuf **abp, size_t min_sz, size_t max_sz)
 	struct aubuf *ab;
 	int err;
 
-	if (!abp || !min_sz)
+	if (!abp)
 		return EINVAL;
 
 	ab = mem_zalloc(sizeof(*ab), aubuf_destructor);
@@ -178,7 +178,7 @@ void aubuf_set_silence(struct aubuf *ab, double silence)
  */
 int aubuf_resize(struct aubuf *ab, size_t min_sz, size_t max_sz)
 {
-	if (!ab || !min_sz)
+	if (!ab)
 		return EINVAL;
 
 	mtx_lock(ab->lock);
@@ -240,11 +240,9 @@ int aubuf_append_auframe(struct aubuf *ab, struct mbuf *mb,
 
 	if (ab->max_sz && ab->cur_sz > ab->max_sz) {
 #if AUBUF_DEBUG
-		if (ab->started) {
-			++ab->stats.or;
-			(void)re_printf("aubuf: %p overrun (cur=%zu/%zu)\n",
-					ab, ab->cur_sz, ab->max_sz);
-		}
+		++ab->stats.or;
+		(void)re_printf("aubuf: %p overrun (cur=%zu/%zu)\n",
+				ab, ab->cur_sz, ab->max_sz);
 #endif
 		f = list_ledata(ab->afl.head);
 		if (f) {


### PR DESCRIPTION
    The write functions should simply write data to aubuf. The overrun check should
    be used only to bound the buffer to the given max size.
    
    On the first read the latency can be controlled by dropping old data.

This simplifies the usage of aubuf by moving the "low latency" buffer drops at start of the stream from write function to the read function.

- aubuf: move low latency start to read function
- aubuf: allow zero as min_sz/wish_sz
