### PR TITLE
aubuf timestamp optional

### DIFF
--- a/include/rem_auframe.h
+++ b/include/rem_auframe.h
@@ -2,6 +2,8 @@
  * Audio frame
  */
 
+#define AUDIO_TIMEBASE 1000000U
+
 /**
  * Defines a frame of audio samples
  */
@@ -42,3 +44,4 @@ static inline void auframe_update(struct auframe *af, void *sampv,
 size_t auframe_size(const struct auframe *af);
 void   auframe_mute(struct auframe *af);
 double auframe_level(struct auframe *af);
+size_t auframe_bytes_to_timestamp(const struct auframe *af, size_t n);

--- a/src/aubuf/ajb.h
+++ b/src/aubuf/ajb.h
@@ -4,8 +4,6 @@
  * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
  */
 
-#define AUDIO_TIMEBASE 1000000U
-
 enum ajb_state {
 	AJB_GOOD = 0,
 	AJB_LOW,

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -66,14 +66,6 @@ static void aubuf_destructor(void *arg)
 }
 
 
-static size_t auframe_bytes_to_timestamp(const struct auframe *af, size_t n)
-{
-	size_t sample_size = aufmt_sample_size(af->fmt);
-
-	return n * AUDIO_TIMEBASE / (af->srate * af->ch * sample_size);
-}
-
-
 static void read_auframe(struct aubuf *ab, struct auframe *af)
 {
 	struct le *le = ab->afl.head;

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -24,7 +24,7 @@ struct aubuf {
 	size_t max_sz;
 	size_t fill_sz;         /**< To fill size                            */
 	size_t pkt_sz;          /**< Packet size                             */
-	size_t written_sz;      /**< Written size                            */
+	size_t wr_sz;           /**< Written size                            */
 	bool started;
 	uint64_t ts;
 
@@ -239,12 +239,12 @@ int aubuf_append_auframe(struct aubuf *ab, struct mbuf *mb,
 
 	if (!f->af.timestamp && f->af.srate && f->af.ch) {
 		f->af.timestamp =
-			auframe_bytes_to_timestamp(&f->af, ab->written_sz);
+			auframe_bytes_to_timestamp(&f->af, ab->wr_sz);
 	}
 
 	list_insert_sorted(&ab->afl, frame_less_equal, NULL, &f->le, f);
 	ab->cur_sz += sz;
-	ab->written_sz += sz;
+	ab->wr_sz += sz;
 
 	if (ab->max_sz && ab->cur_sz > ab->max_sz) {
 #if AUBUF_DEBUG
@@ -454,6 +454,7 @@ void aubuf_flush(struct aubuf *ab)
 	list_flush(&ab->afl);
 	ab->fill_sz = ab->wish_sz;
 	ab->cur_sz  = 0;
+	ab->wr_sz   = 0;
 	ab->ts      = 0;
 
 	mtx_unlock(ab->lock);

--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -90,7 +90,9 @@ static void read_auframe(struct aubuf *ab, struct auframe *af)
 		if (!mbuf_get_left(f->mb)) {
 			mem_deref(f);
 		}
-		else if (af->srate && af->ch && sample_size) {
+		else if (f->af.timestamp && af->srate && af->ch &&
+			 sample_size) {
+
 			f->af.timestamp += n * AUDIO_TIMEBASE /
 				(af->srate * af->ch * sample_size);
 		}

--- a/src/auframe/auframe.c
+++ b/src/auframe/auframe.c
@@ -101,3 +101,11 @@ double auframe_level(struct auframe *af)
 
 	return af->level;
 }
+
+
+size_t auframe_bytes_to_timestamp(const struct auframe *af, size_t n)
+{
+	size_t sample_size = aufmt_sample_size(af->fmt);
+
+	return n * AUDIO_TIMEBASE / (af->srate * af->ch * sample_size);
+}


### PR DESCRIPTION
- aubuf: prevent faulty timestamps for partial read
- aubuf: set correct timestamps if app provides zero
- aubuf,auframe: move auframe_bytes_to_timestamp() to auframe
- aubuf: reset also written_sz in aubuf_flush()
