### PR TITLE
auframe: auframe_bytes_to_timestamp use uint64_t

### DIFF
--- a/include/rem_auframe.h
+++ b/include/rem_auframe.h
@@ -44,4 +44,4 @@ static inline void auframe_update(struct auframe *af, void *sampv,
 size_t auframe_size(const struct auframe *af);
 void   auframe_mute(struct auframe *af);
 double auframe_level(struct auframe *af);
-size_t auframe_bytes_to_timestamp(const struct auframe *af, size_t n);
+uint64_t auframe_bytes_to_timestamp(const struct auframe *af, size_t n);

--- a/src/auframe/auframe.c
+++ b/src/auframe/auframe.c
@@ -103,9 +103,10 @@ double auframe_level(struct auframe *af)
 }
 
 
-size_t auframe_bytes_to_timestamp(const struct auframe *af, size_t n)
+uint64_t auframe_bytes_to_timestamp(const struct auframe *af, size_t n)
 {
 	size_t sample_size = aufmt_sample_size(af->fmt);
 
-	return n * AUDIO_TIMEBASE / (af->srate * af->ch * sample_size);
+	return ((uint64_t) n) * AUDIO_TIMEBASE /
+		(af->srate * af->ch * sample_size);
 }


### PR DESCRIPTION
The correct type for timestamp is `uint64_t`.