### PR TITLE
aubuf: avoid underflow of cur_sz

### DIFF
--- a/src/aubuf/aubuf.c
+++ b/src/aubuf/aubuf.c
@@ -254,7 +254,7 @@ int aubuf_append_auframe(struct aubuf *ab, struct mbuf *mb,
 #endif
 		f = list_ledata(ab->afl.head);
 		if (f) {
-			ab->cur_sz -= sz;
+			ab->cur_sz -= mbuf_get_left(f->mb);
 			mem_deref(f);
 		}
 	}


### PR DESCRIPTION
Frame `f` in line 256 may be different from `f` in line 245.

Thus `sz` may be not the correct size in line 257. (E.g. with opus codec where frames have dynamical size)

Then it happend that `ab->cur_sz` underflow, so become a very big unsigned int value.