### PR TITLE
auframe: add struct auframe id field

### DIFF
--- a/include/rem_auframe.h
+++ b/include/rem_auframe.h
@@ -15,7 +15,8 @@ struct auframe {
 	uint64_t timestamp;  /**< Timestamp in AUDIO_TIMEBASE units */
 	double level;        /**< Audio level in dBov               */
 	uint8_t ch;          /**< Channels                          */
-	uint8_t padding[7];
+	uint16_t id;         /**< Frame/Channel identifier          */
+	uint8_t padding[5];
 };
 
 void auframe_init(struct auframe *af, enum aufmt fmt, void *sampv,

--- a/src/auframe/auframe.c
+++ b/src/auframe/auframe.c
@@ -40,6 +40,7 @@ void auframe_init(struct auframe *af, enum aufmt fmt, void *sampv,
 	af->srate = srate;
 	af->level = AULEVEL_UNDEF;
 	af->ch = ch;
+	af->id = 0;
 }
 
 


### PR DESCRIPTION
This is useful for packing multiple independent frames into one aubuf and then split them in a separate thread to record multiple tracks.