### PR TITLE
aubuf/ajb: reset reference timestamp if skew is too high

### DIFF
--- a/src/aubuf/ajb.c
+++ b/src/aubuf/ajb.c
@@ -26,6 +26,7 @@ enum {
 	BUFTIME_EMA_COEFF  = 128,  /* Divisor for Buftime EMA coeff.     */
 	BUFTIME_LO         = 125,  /* 125% of jitter                     */
 	BUFTIME_HI         = 175,  /* 175% of jitter                     */
+	SKEW_MAX           = 10,   /* Max skew in [ms]                   */
 };
 
 
@@ -249,8 +250,8 @@ void ajb_calc(struct ajb *ajb, const struct auframe *af, size_t cur_sz)
 
 	bufmax = MAX(bufmax, bufmin + 7 * ptime / 6);
 
-	/* reset time base if a frame is missing */
-	if (ts - ajb->ts > ptime)
+	/* reset time base if a frame is missing or skew is too high */
+	if (ts - ajb->ts > ptime || da > SKEW_MAX * 1000)
 		ajb->ts0 = 0;
 
 	if ((uint32_t) ajb->avbuftime < bufmin)


### PR DESCRIPTION
Relates to adaptive jitter buffer mode.

Fixes jitter computation and as a consequence a lot of unexpected frame drops if the received RTP stream has an inaccurate timebase.

E.g. the following gstreamer pipeline generates an RTP stream with to fast time base
```
gst-launch-1.0 -v souphttpsrc location=https://orf-live.ors-shoutcast.at/fm4-q1a ssl-strict=false ! decodebin expose-all-streams=false ! audiorate skip-to-first=true ! audioconvert ! audioresample ! avenc_g722 ! rtpg722pay ! udpsink host=224.0.1.194 port=5004
```

The time difference between real time and RTP time stamps becomes more and more negative.

It is 15 us/s too fast.

Here an image of the faulty jitter computation:
![89020647-c12e-4ea6-a864-d940fa4f3f11](https://user-images.githubusercontent.com/14180877/210238254-fde86301-85c9-40f5-8898-31e26958482e.png)
